### PR TITLE
rename restart

### DIFF
--- a/dc.ps1
+++ b/dc.ps1
@@ -32,7 +32,7 @@ function dc(
         "up" {
             docker compose up ($attach ? "" : "-d") ($noWait -or $attach ? "" : "--wait") $Rest
         }
-        "restart" {
+        "reup" {
             dc down $Rest
             dc up $attach $noWait $Rest
         }

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 A `docker compose` wrapper with some added niceties.
 
-Who wants to type `docker compose` when they could type `dc` instead? Shouldn't `docker compose up` do `-d` or `--wait` by default? Why doesn't `docker compose` have a `restart` command[^1]?
+Who wants to type `docker compose` when they could type `dc` instead? Shouldn't `docker compose up` do `-d` or `--wait` by default? Why doesn't `docker compose` have a single command to start over completely?
 
 ## Installation
 
@@ -17,7 +17,7 @@ Add-Content -Path $profile -Value "`n. $pwd\dc\dc.ps1"
 ```powershell
 dc up
 
-dc restart
+dc reup
 
 dc down
 
@@ -25,5 +25,3 @@ dc up --no-wait
 
 dc <any `docker compose` command>
 ```
-
-[^1]: I'm pretty sure `docker compose` didn't have a `restart` command when I created the first version of `dc` many years ago. It does now. I'm open to renaming `restart` in this wrapper (so as not to hide `docker compose restart`) if a good alternative is suggested.


### PR DESCRIPTION
since docker does have a restart with its own semantics now, perhaps it is a good idea to rename restart in the wrapper.
I chose 'reup' because it is also less characters than 'restart' and sort of communicated the 'down, up' that is happening